### PR TITLE
fix: Handle config `start_date` as a date-time value

### DIFF
--- a/tap_google_search_console/client.py
+++ b/tap_google_search_console/client.py
@@ -94,12 +94,12 @@ class GoogleSearchConsoleStream(Stream):
         backfill = self.config["backfill_days"]
 
         # add in a couple days to cover overlap
-        starting_ts = datetime.date.fromisoformat(input_ts) - datetime.timedelta(
+        starting_ts = datetime.datetime.fromisoformat(input_ts) - datetime.timedelta(
             days=backfill,
         )
-        delta = datetime.date.fromisoformat(self.end_date) - starting_ts
+        delta = datetime.datetime.fromisoformat(self.end_date) - starting_ts
         return [
-            (starting_ts + datetime.timedelta(days=d)).isoformat()
+            (starting_ts + datetime.timedelta(days=d)).date().isoformat()
             for d in range(delta.days)
         ]
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,7 +9,7 @@ from singer_sdk.testing import get_tap_test_class
 from tap_google_search_console.tap import TapGoogleSearchConsole
 
 SAMPLE_CONFIG = {
-    "start_date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
+    "start_date": datetime.datetime.now(datetime.timezone.utc).isoformat(),
     "site_url": "sc-domain:meltano.com",
     "client_secrets": '{"type": "service_account","project_id": "1234","private_key_id": "1234","private_key": "-----BEGIN PRIVATE KEY-----\\\\n-----END PRIVATE KEY-----\\n","client_email": "me@.iam.gserviceaccount.com","client_id": "123","auth_uri": "https://accounts.google.com/o/oauth2/auth","token_uri": "https://oauth2.googleapis.com/token","auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs","client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/something.iam.gserviceaccount.com"}',
 }


### PR DESCRIPTION
Passing a date-time value in `start_date` results in the error

```
ValueError: Invalid isoformat string: '2026-01-01T00:00:00'
```

The setting is already defined as `th.DateTimeType`, so I see no harm in supporting date-time values (and continuing to support date values by extension).