### PR TITLE
fix: Invalid primary keys for `performance_report_keys` stream

### DIFF
--- a/tap_google_search_console/schemas/performance_report_keys.json
+++ b/tap_google_search_console/schemas/performance_report_keys.json
@@ -2,27 +2,53 @@
     "type": "object",
     "properties": {
         "site_url": {
-            "type": ["string", "null"]
+            "type": [
+                "string",
+                "null"
+            ]
         },
         "clicks": {
-            "type": ["integer", "null"]
+            "type": [
+                "integer",
+                "null"
+            ]
         },
         "impressions": {
-            "type": ["integer", "null"]
+            "type": [
+                "integer",
+                "null"
+            ]
         },
         "ctr": {
-            "type": ["number", "null"]
+            "type": [
+                "number",
+                "null"
+            ]
         },
         "position": {
-            "type": ["number", "null"]
+            "type": [
+                "number",
+                "null"
+            ]
         },
         "date": {
-            "type": ["string", "null"],
+            "type": [
+                "string",
+                "null"
+            ],
             "format": "date"
         },
         "keys": {
-            "type": ["array", "null"],
-            "items": { "type": ["string", "null"] },
+            "type": [
+                "array",
+                "null"
+            ],
+            "items": {
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
             "description": "Raw 'keys' array returned by Google Search Console API."
         }
     }

--- a/tap_google_search_console/schemas/performance_report_keys.json
+++ b/tap_google_search_console/schemas/performance_report_keys.json
@@ -1,6 +1,9 @@
 {
     "type": "object",
     "properties": {
+        "site_url": {
+            "type": ["string", "null"]
+        },
         "clicks": {
             "type": ["integer", "null"]
         },

--- a/tap_google_search_console/streams.py
+++ b/tap_google_search_console/streams.py
@@ -79,10 +79,6 @@ class PerformanceReportKeys(GoogleSearchConsoleStream):
     name = "performance_report_keys"
     dimensions = (
         "date",  # Include 'date' for replication key support
-        "query",
-        "page",
-        "country",
-        "device",
     )
     schema_filepath = SCHEMAS_DIR / (name + ".json")
     # Use auto aggregation type (byProperty is invalid for multi-dimension)


### PR DESCRIPTION
Dimension keys are not expanded in the `performance_report_keys` stream, so the current primary key configuration causes an error when loading into Postgres:

```
psycopg2.errors.UndefinedColumn: column "query" named in key does not exist
```